### PR TITLE
Add configuration instructions for NO_PROXY and fix wrongly written characters and punctuation errors

### DIFF
--- a/docs/deploy/standalone.md
+++ b/docs/deploy/standalone.md
@@ -115,3 +115,5 @@ sudo docker run -d --privileged --restart=always \
   -e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,.svc,.cluster.local,example.com" \
   sealio/walrus:<VERSION>
 ```
+> Note: 
+  > - If there are any connectors (K8s, cloud, or any other infrastructure) that you want to add to Walrus and should bypass the proxy, make sure to incorporate their access addresses (e.g., the K8s API server addresses in kubeconfig or the domain names/IP addresses for specific cloud URLs) into the `NO_PROXY` configuration when running Walrus.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deploy/standalone.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deploy/standalone.md
@@ -115,3 +115,5 @@ sudo docker run -d --privileged --restart=always \
   -e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,.svc,.cluster.local,example.com" \
   sealio/walrus:<VERSION>
 ```
+> 注意：
+> - 如果有任何连接器(K8s、云或任何其他基础设施)想要添加到Walrus，并且应该绕过代理，请确保在运行Walrus时，将其访问地址(例如，kubeconfig中的K8s API server地址、特定云URL的域名或IP地址)合并到“NO_PROXY”配置中。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/tutorials/integrate-with-cicd.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/tutorials/integrate-with-cicd.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # 集成 CICD 工具
 
-本教程介绍如何如何同过 Walrus CLI 与您的 CI/CD 工具集成，以实现自动化的部署流程。
+本教程介绍如何通过 Walrus CLI 与您的 CI/CD 工具集成，以实现自动化的部署流程。
 
 ## 先决条件
 
@@ -16,16 +16,16 @@ sidebar_position: 3
 
 首先，您需要创建一个 API 密钥，以便让 Walrus CLI 能够与 Walrus 服务进行通信。
 
-1. 进入`个人中心`的`API 密钥`，点击`添加密钥`，配置名称和密钥的过期时间。
+1. 进入`个人中心`的`API 密钥`，点击`添加密钥`，配置名称和密钥的过期时间；
 2. 完成后，复制生成的密钥，以备后用。
 
 ### Walrus CLI 和 CI/CD 工具集成
 
 我们以 CLI 和 GitHub Actions 集成为例。
 
-1. 进入 GitHub 仓库，在目录 `.github/workflows` 下创建 `ci.yaml` 文件，并在其中定义您的 CI/CD 工作流。。
-2. 在工作流程中，配置 GitHub Actions 的密钥，包括 `CI_REGISTRY_PASSWORD`，`CI_WALRUS_SERVER` 和 `CI_WALRUS_TOKEN`，以便安全地存储敏感信息，`CI_WALRUS_SERVER` 的格式为 https://domian:port/。
-3. 以下为 `ci.yaml`` 样例：
+1. 进入 GitHub 仓库，在目录 `.github/workflows` 下创建 `ci.yaml` 文件，并在其中定义您的 CI/CD 工作流；
+2. 在工作流程中，配置 GitHub Actions 的密钥，包括 `CI_REGISTRY_PASSWORD`，`CI_WALRUS_SERVER` 和 `CI_WALRUS_TOKEN`，以便安全地存储敏感信息，`CI_WALRUS_SERVER` 的格式为 https://domian:port/；
+3. 以下为 `ci.yaml` 样例：
 
 ```yaml
 name: ci


### PR DESCRIPTION
1. Add configuration instructions for NO_PROXY
2. Fix wrongly written characters and punctuation errors