### PR TITLE
fix: wrong shell interpreter & filter out archived repos

### DIFF
--- a/docs/deploy/airgap.md
+++ b/docs/deploy/airgap.md
@@ -16,13 +16,13 @@ Retrieve the `walrus-images.txt`, `walrus-save-images.sh` and `walrus-load-image
 
 1. Use `walrus-save-images.sh` to download offline images on a Docker host with internet access:
 ```shell
-sh walrus-save-images.sh --image-list walrus-images.txt
+./walrus-save-images.sh --image-list walrus-images.txt
 ```
 
 2. Upload the saved offline image package `walrus-images.tar.gz` and `walrus-load-images.sh` to a Docker host that has access to the container registry. Use `walrus-load-images.sh` to upload the offline images. Taking Harbor as an example for the container registry (if not, ensure to create a `sealio` project in the container registry beforehand).
 ```shell
 docker login registry.example.com --username admin --password Harbor12345
-sh walrus-load-images.sh --registry registry.example.com --harbor-user admin --harbor-password Harbor12345
+./walrus-load-images.sh --registry registry.example.com --harbor-user admin --harbor-password Harbor12345
 ```
 
 ## Preparing offline catalog
@@ -36,7 +36,7 @@ You can refer to the following script to clone all repositories from `walrus-cat
 ORG_NAME="walrus-catalog"
 
 # Get all repos in the Walrus catalog org
-REPOS=$(curl -s "https://api.github.com/orgs/$ORG_NAME/repos" | jq -r '.[].name')
+REPOS=$(curl -s "https://api.github.com/orgs/$ORG_NAME/repos" | jq -r '.[] | select(.archived == false) | .name')
 
 for REPO_NAME in $REPOS; do
   # Clone repo

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deploy/airgap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deploy/airgap.md
@@ -17,13 +17,13 @@ sidebar_position: 2
 
 1. 使用 `walrus-save-images.sh` 在可以联网的Docker主机下载离线镜像，参考命令如下：
 ```shell
-sh walrus-save-images.sh --image-list walrus-images.txt
+./walrus-save-images.sh --image-list walrus-images.txt
 ```
 
 2. 将保存的离线镜像包 `walrus-images.tar.gz` 和 `walrus-load-images.sh` 上传到可以访问内网镜像仓库的Docker主机，使用 `walrus-load-images.sh` 上传离线镜像，内网镜像仓库以Harbor为例（如果不是Harbor，需要提前在镜像仓库中创建 `sealio` 项目），参考命令如下：
 ```shell
 docker login registry.example.com --username admin --password Harbor12345
-sh walrus-load-images.sh --registry registry.example.com --harbor-user admin --harbor-password Harbor12345
+./walrus-load-images.sh --registry registry.example.com --harbor-user admin --harbor-password Harbor12345
 ```
 
 ## 准备离线模板库
@@ -37,7 +37,7 @@ sh walrus-load-images.sh --registry registry.example.com --harbor-user admin --h
 ORG_NAME="walrus-catalog"
 
 # Get all repos in the Walrus catalog org
-REPOS=$(curl -s "https://api.github.com/orgs/$ORG_NAME/repos" | jq -r '.[].name')
+REPOS=$(curl -s "https://api.github.com/orgs/$ORG_NAME/repos" | jq -r '.[] | select(.archived == false) | .name')
 
 for REPO_NAME in $REPOS; do
   # Clone repo

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v0.4/deploy/airgap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v0.4/deploy/airgap.md
@@ -17,13 +17,13 @@ sidebar_position: 2
 
 1. 使用 `walrus-save-images.sh` 在可以联网的Docker主机下载离线镜像，参考命令如下：
 ```shell
-sh walrus-save-images.sh --image-list walrus-images.txt
+./walrus-save-images.sh --image-list walrus-images.txt
 ```
 
 2. 将保存的离线镜像包 `walrus-images.tar.gz` 和 `walrus-load-images.sh` 上传到可以访问内网镜像仓库的Docker主机，使用 `walrus-load-images.sh` 上传离线镜像，内网镜像仓库以Harbor为例（如果不是Harbor，需要提前在镜像仓库中创建 `sealio` 项目），参考命令如下：
 ```shell
 docker login registry.example.com --username admin --password Harbor12345
-sh walrus-load-images.sh --registry registry.example.com --harbor-user admin --harbor-password Harbor12345
+./walrus-load-images.sh --registry registry.example.com --harbor-user admin --harbor-password Harbor12345
 ```
 
 ## 准备离线模板库
@@ -37,7 +37,7 @@ sh walrus-load-images.sh --registry registry.example.com --harbor-user admin --h
 ORG_NAME="walrus-catalog"
 
 # Get all repos in the Walrus catalog org
-REPOS=$(curl -s "https://api.github.com/orgs/$ORG_NAME/repos" | jq -r '.[].name')
+REPOS=$(curl -s "https://api.github.com/orgs/$ORG_NAME/repos" | jq -r '.[] | select(.archived == false) | .name')
 
 for REPO_NAME in $REPOS; do
   # Clone repo


### PR DESCRIPTION
Fix in airgap docs:
- Wrong shell interpreter when running in linux.
- Filter out archived repos when downloading catalog repos.